### PR TITLE
preview mode for markdown, resolve memory issue with calendar view

### DIFF
--- a/MarkdownTodo/Views/CalendarOverview.swift
+++ b/MarkdownTodo/Views/CalendarOverview.swift
@@ -22,12 +22,11 @@ struct CalendarOverview: View {
     @State private var reminders: [EKReminder] = []
 
     private func destination(for date: Date) -> some View {
-        selectedDate = date
         return SelectedDateView(date: date)
     }
 
     var body: some View {
-        CalendarView(interval: month) { date in
+        CalendarView(interval: month, selectedDate: $selectedDate) { date in
             NavigationLink(destination: destination(for: date)) {
                 Text(String(self.calendar.component(.day, from: date)))
                     .frame(

--- a/MarkdownTodo/Views/Component/EKReminderEditView.swift
+++ b/MarkdownTodo/Views/Component/EKReminderEditView.swift
@@ -24,11 +24,13 @@ struct EKReminderEditView: View {
 struct EKReminderEditViewSimple: View {
     @Binding var reminder: EKReminder
     @Binding var showFull: Bool
+    @State private var showPreview: Bool = false
     var body: some View {
         List {
             Toggle("Show Full", isOn: $showFull)
+            Toggle("Show Preview", isOn: $showPreview)
             TextField("Title", text: $reminder.title)
-            MarkdownView(label: "Description", text: $reminder.unwrappedNotes)
+            MarkdownView(label: "Description", text: $reminder.unwrappedNotes, showPreview: $showPreview)
         }
     }
 }
@@ -36,10 +38,12 @@ struct EKReminderEditViewSimple: View {
 struct EKReminderEditViewFull: View {
     @Binding var reminder: EKReminder
     @Binding var showFull: Bool
+    @State private var showPreview: Bool = false
     var body: some View {
         List {
             Section {
                 Toggle("Show Full", isOn: $showFull)
+                Toggle("Show Markdown", isOn: $showPreview)
                 TextField("Title", text: $reminder.title)
             }
             Section(header: Text("Detail")) {
@@ -69,7 +73,7 @@ struct EKReminderEditViewFull: View {
             Section(header: Text("Other")) {
                 LinkField(url: $reminder.url)
                     .modifier(LabelModifier(label: "URL"))
-                MarkdownView(label: "Description", text: $reminder.unwrappedNotes)
+                MarkdownView(label: "Description", text: $reminder.unwrappedNotes, showPreview: $showPreview)
             }
         }
     }

--- a/MarkdownTodo/Views/Component/MarkdownView.swift
+++ b/MarkdownTodo/Views/Component/MarkdownView.swift
@@ -27,7 +27,7 @@ struct MarkdownPreviewView: UIViewRepresentable {
 struct MarkdownView: View {
     var label: String
     @Binding var text: String
-    @State private var showPreview = false
+    @Binding var showPreview: Bool
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -48,6 +48,6 @@ struct MarkdownView: View {
 
 struct MarkdownView_Previews: PreviewProvider {
     static var previews: some View {
-        MarkdownView(label: "Test", text: .constant("Some description"))
+        MarkdownView(label: "Test", text: .constant("Some description"), showPreview: .constant(true))
     }
 }

--- a/MarkdownTodo/Views/Component/Pickers/CalendarDatePicker.swift
+++ b/MarkdownTodo/Views/Component/Pickers/CalendarDatePicker.swift
@@ -18,7 +18,7 @@ struct CalendarDatePicker: View {
     var action: (Date) -> Void
 
     var body: some View {
-        CalendarView(interval: month) { date in
+        CalendarView(interval: month, selectedDate: $selectedDate) { date in
             Button(String(self.calendar.component(.day, from: date))) {
                 action(date)
             }

--- a/MarkdownTodo/Views/Component/ThirdParty/CalendarView.swift
+++ b/MarkdownTodo/Views/Component/ThirdParty/CalendarView.swift
@@ -53,9 +53,11 @@ struct WeekView<DateView>: View where DateView: View {
 
     let week: Date
     let content: (Date) -> DateView
+    @Binding var selectedDate: Date
 
-    init(week: Date, @ViewBuilder content: @escaping (Date) -> DateView) {
+    init(week: Date, selectedDate: Binding<Date>, @ViewBuilder content: @escaping (Date) -> DateView) {
         self.week = week
+        self._selectedDate = selectedDate
         self.content = content
     }
 
@@ -75,12 +77,19 @@ struct WeekView<DateView>: View where DateView: View {
                 HStack {
                     if self.calendar.isDate(self.week, equalTo: date, toGranularity: .month) {
                         self.content(date)
+                            .onAppear(perform: {
+                                self.updateDate(date: date)
+                            })
                     } else {
                         self.content(date).hidden()
                     }
                 }
             }
         }
+    }
+
+    private func updateDate(date: Date) {
+        self.selectedDate = date
     }
 }
 
@@ -90,14 +99,17 @@ struct MonthView<DateView>: View where DateView: View {
     let month: Date
     let showHeader: Bool
     let content: (Date) -> DateView
+    @Binding var selectedDate: Date
 
     init(
         month: Date,
         showHeader: Bool = true,
+        selectedDate: Binding<Date>,
         @ViewBuilder content: @escaping (Date) -> DateView
     ) {
         self.month = month
         self.content = content
+        self._selectedDate = selectedDate
         self.showHeader = showHeader
     }
 
@@ -126,7 +138,7 @@ struct MonthView<DateView>: View where DateView: View {
             }
 
             ForEach(weeks, id: \.self) { week in
-                WeekView(week: week, content: self.content)
+                WeekView(week: week, selectedDate: $selectedDate, content: self.content)
             }
         }
     }
@@ -137,10 +149,12 @@ struct CalendarView<DateView>: View where DateView: View {
 
     let interval: DateInterval
     let content: (Date) -> DateView
+    @Binding var selectedDate: Date
 
-    init(interval: DateInterval, @ViewBuilder content: @escaping (Date) -> DateView) {
+    init(interval: DateInterval, selectedDate: Binding<Date>, @ViewBuilder content: @escaping (Date) -> DateView) {
         self.interval = interval
         self.content = content
+        self._selectedDate = selectedDate
     }
 
     private var months: [Date] {
@@ -154,7 +168,7 @@ struct CalendarView<DateView>: View where DateView: View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack {
                 ForEach(months, id: \.self) { month in
-                    MonthView(month: month, content: self.content)
+                    MonthView(month: month, selectedDate: $selectedDate, content: self.content)
                 }
             }
         }


### PR DESCRIPTION
- Calendar view has a memory issue because the selectedDate is being modified during rendering of the view, updated this to a two-way binding 
- The edit event view has no ability to toggle preview for Markdown, added a preview toggle